### PR TITLE
Replaced Stale tests with a tiny working one.

### DIFF
--- a/app/test/widget_test.dart
+++ b/app/test/widget_test.dart
@@ -1,29 +1,7 @@
-// This is a basic Flutter widget test.
-// To perform an interaction with a widget in your test, use the WidgetTester utility that Flutter
-// provides. For example, you can send tap and scroll gestures. You can also use WidgetTester to
-// find child widgets in the widget tree, read text, and verify that the values of widget properties
-// are correct.
-
-import 'package:flutter/material.dart';
-import 'package:flutter_test/flutter_test.dart';
-
-import 'package:app/main.dart';
+// Shows how a basic test is written in dart/flutter
 
 void main() {
-  testWidgets('Counter increments smoke test', (WidgetTester tester) async {
-    // Build our app and trigger a frame.
-    await tester.pumpWidget(MyApp());
-
-    // Verify that our counter starts at 0.
-    expect(find.text('0'), findsOneWidget);
-    expect(find.text('1'), findsNothing);
-
-    // Tap the '+' icon and trigger a frame.
-    await tester.tap(find.byIcon(Icons.add));
-    await tester.pump();
-
-    // Verify that our counter has incremented.
-    expect(find.text('0'), findsNothing);
-    expect(find.text('1'), findsOneWidget);
+  test('test sum', () {
+    expect(2 + 2, 4);
   });
 }


### PR DESCRIPTION
The errors lingering on the test directory were distracting as Android Studio seems to compile time check the  ```/test``` directory when in ```debug``` mode. Just a tiny change I thought would remove the compile time errors on the project.